### PR TITLE
Fix misssing dependency r-stringr which was introduced in version 1.6.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,9 @@ source:
   sha256: 8765875573a29622c822c6a6ab0c93afe418b49bf7aec0ba0dd3c55b7e81175d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
+
   rpaths:
     - lib/R/lib/
     - lib/
@@ -31,7 +32,9 @@ requirements:
     - r-jsonlite
     - r-knitr >=1.14
     - r-rprojroot
+    - r-stringr >=1.2.0
     - r-yaml >=2.1.5
+
   run:
     - r-base
     - r-base64enc
@@ -41,6 +44,7 @@ requirements:
     - r-jsonlite
     - r-knitr >=1.14
     - r-rprojroot
+    - r-stringr >=1.2.0
     - r-yaml >=2.1.5
 
 test:
@@ -59,3 +63,4 @@ extra:
     - johanneskoester
     - bgruening
     - mdehollander
+    - jdblischak


### PR DESCRIPTION
I was getting a strange error when running `rmarkdown::render_site` in my conda environment that had the latest versions of r-rmarkdown (1.6) and r-stringr (1.1.0) from conda-forge. This was due to a missing dependency that was added in r-rmarkdown 1.6 (r-stringr >=1.2.0) but wasn't included when the feedstock was updated from 1.5 to 1.6 in PR https://github.com/conda-forge/r-rmarkdown-feedstock/pull/1. To fix this, I update the r-stringr-feedstock to 1.2.0 in https://github.com/conda-forge/r-stringr-feedstock/pull/2, and this PR updates the recipes for r-rmarkdown 1.6.

Please review @johanneskoester @bgruening @mdehollander