### PR TITLE
Add pandoc as run-time requirement.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 8765875573a29622c822c6a6ab0c93afe418b49bf7aec0ba0dd3c55b7e81175d
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win32]
 
   rpaths:
@@ -36,6 +36,7 @@ requirements:
     - r-yaml >=2.1.5
 
   run:
+    - pandoc >=1.12.3
     - r-base
     - r-base64enc
     - r-catools


### PR DESCRIPTION
rmarkdown uses pandoc to convert files to various formats. I've added it as a run-time requirement.

Demonstrating the issue:

```
$ conda create -n testrmd r r-rmarkdown
$ source activate testrmd
$ R
> library("rmarkdown")
> file.create("test.Rmd")
> render("test.Rmd", html_document())
Error: pandoc version 1.12.3 or higher is required and was not found.
> file.remove("test.Rmd")
$ source deactivate
$ conda remove -n testrmd --all
```

Fortunately this missing dependency likely doesn't negatively impact most conda R users because pandoc is installed with [r-essentials](https://github.com/conda-forge/r-essentials-feedstock) (which depends on [notebook](https://github.com/conda-forge/notebook-feedstock) -> [nbconvert](https://github.com/conda-forge/nbconvert-feedstock) -> [pandoc](https://github.com/conda-forge/pandoc-feedstock)).

@johanneskoester @bgruening @mdehollander