### PR TITLE
Drop `pandoc` upper bound

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -19,11 +19,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,15 +54,20 @@ requirements:
 
 test:
   requires:
+    - r-testthat
     - xorg-libxt                             # [not win]
     - xorg-libsm                             # [not win]
+  source_files:
+    - tests/
   commands:
     - $R -e "library('rmarkdown')"           # [not win]
     - "\"%R%\" -e \"library('rmarkdown')\""  # [win]
     - $R -e "capabilities()" || true         # [not win]
     - $R -e "grSoftVersion()" || true        # [not win]
-    - $R -e "x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)"  # [not win]
+    - $R -e "x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)"           # [not win]
     - "\"%R%\" -e \"x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)\""  # [win]
+    - $R -e "testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
+    - "\"%R%\" -e \"testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')\""  # [win]
 
 about:
   home: https://pkgs.rstudio.com/rmarkdown/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ test:
   requires:
     - r-testthat
     - r-shiny
+    - texlive-core                           # [not win]
     - xorg-libxt                             # [not win]
     - xorg-libsm                             # [not win]
   source_files:
@@ -67,7 +68,7 @@ test:
     - $R -e "grSoftVersion()" || true        # [not win]
     - $R -e "x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)"           # [not win]
     - "\"%R%\" -e \"x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)\""  # [win]
-    - $R -e "tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
+    - $R -e "testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
     - "\"%R%\" -e \"tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')\""  # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -50,7 +50,7 @@ requirements:
     - r-tinytex >=0.31
     - r-xfun >=0.36
     - r-yaml >=2.1.19
-    - pandoc >=1.14,<3.0
+    - pandoc >=1.14
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ requirements:
 test:
   requires:
     - r-testthat
+    - r-shiny
     - xorg-libxt                             # [not win]
     - xorg-libsm                             # [not win]
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,8 +67,8 @@ test:
     - $R -e "grSoftVersion()" || true        # [not win]
     - $R -e "x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)"           # [not win]
     - "\"%R%\" -e \"x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)\""  # [win]
-    - $R -e "testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
-    - "\"%R%\" -e \"testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')\""  # [win]
+    - $R -e "tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
+    - "\"%R%\" -e \"tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')\""  # [win]
 
 about:
   home: https://pkgs.rstudio.com/rmarkdown/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
   requires:
     - r-testthat
     - r-shiny
-    - texlive-core                           # [not win]
+    - perl
     - xorg-libxt                             # [not win]
     - xorg-libsm                             # [not win]
   source_files:
@@ -68,7 +68,7 @@ test:
     - $R -e "grSoftVersion()" || true        # [not win]
     - $R -e "x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)"           # [not win]
     - "\"%R%\" -e \"x <- tempfile(fileext = '.Rmd'); file.create(x); rmarkdown::render(x)\""  # [win]
-    - $R -e "testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
+    - $R -e "tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')"           # [not win]
     - "\"%R%\" -e \"tinytex::install_tinytex();testthat::test_dir('tests/testthat/', package='rmarkdown', load_package='installed')\""  # [win]
 
 about:


### PR DESCRIPTION
I can't seem to find any explicit reason on record why `pandoc < 3` was set here. Looking upstream several years I also see no mention of this as a requirement. 

Anyway, it seems to block solving in https://github.com/conda-forge/rstudio-feedstock/pull/21, so I propose we drop it.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
